### PR TITLE
fix: propagate error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ function snoop(fn) {
           arguments: args,
           error,
         });
+        throw error
       } finally {
         callMap[testID].push(callCounter++);
 


### PR DESCRIPTION
This fixes "snooping" a function that throws by re-throwing the error.