### PR TITLE
add optional fn "this" context

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ let testIDCounter = 0;
 let callCounter = 0;
 const callMap = {};
 
-function snoop(fn) {
+function snoop(fn, context = null) {
   const testID = testIDCounter++;
   const calls = [];
 
@@ -13,7 +13,7 @@ function snoop(fn) {
       callMap[testID] = callMap[testID] || [];
 
       try {
-        result = fn.apply(null, args);
+        result = fn.apply(context, args);
 
         calls.push({
           result,


### PR DESCRIPTION
Hi Parmesh - 

I'm using `snoop` with [uvu](https://github.com/lukeed/uvu) and testing and event emitter package that takes an optional context. This change allows me to test that functionality. Could also be expanded to include an `fn.calledWith(context)` method.

Cheers!